### PR TITLE
Game fix for Renegade Ops

### DIFF
--- a/gamefixes/99300.py
+++ b/gamefixes/99300.py
@@ -1,0 +1,10 @@
+""" Game fix Renegade Ops
+"""
+#pylint: disable=C0103
+
+from protonfixes import util
+
+def main():
+    """ This fixed the black screen issue
+    """
+    util.protontricks('d3dcompiler_47')


### PR DESCRIPTION
The game only shows a black screen without `d3dcompiler_47`.


CC https://github.com/ValveSoftware/Proton/issues/5550